### PR TITLE
Bump deno and package versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.33.3
+          deno-version: v1.37.1
 
       - name: Verify formatting
         run: deno fmt --check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:1.33.3
+FROM denoland/deno:1.37.1
 
 # The port that your application listens to.
 EXPOSE 8000

--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,4 @@
-export { serve } from "https://deno.land/std@0.117.0/http/server.ts";
 export {
   Status,
   STATUS_TEXT,
-} from "https://deno.land/std@0.117.0/http/http_status.ts";
+} from "https://deno.land/std@0.204.0/http/http_status.ts";

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684570954,
-        "narHash": "sha256-FX5y4Sm87RWwfu9PI71XFvuRpZLowh00FQpIJ1WfXqE=",
+        "lastModified": 1697456312,
+        "narHash": "sha256-roiSnrqb5r+ehnKCauPLugoU8S36KgmWraHgRqVYndo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3005f20ce0aaa58169cdee57c8aa12e5f1b6e1b3",
+        "rev": "ca012a02bf8327be9e488546faecae5e05d7d749",
         "type": "github"
       },
       "original": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import { serve, Status, STATUS_TEXT } from "../deps.ts";
+import { Status, STATUS_TEXT } from "../deps.ts";
 import { filterIncludesKey, parseParameters } from "./filter.ts";
 import keys from "./public_keys.ts";
 import pgp_key from "./pgp_key.ts";
@@ -11,8 +11,9 @@ import pgp_key from "./pgp_key.ts";
  */
 export default function start(port: number) {
   console.log(`Server listening at :${port}/api`);
-  serve(
-    (req: Request) => {
+  Deno.serve({
+    port,
+    handler: (req: Request) => {
       try {
         const url = new URL(req.url);
 
@@ -20,14 +21,14 @@ export default function start(port: number) {
         if (url.pathname !== "/api" && url.pathname !== "/pgp.asc") {
           return new Response(undefined, {
             status: Status.NotFound,
-            statusText: STATUS_TEXT.get(Status.NotFound),
+            statusText: STATUS_TEXT[Status.NotFound],
           });
         }
 
         if (url.pathname === "/pgp.asc") {
           return new Response(pgp_key, {
             status: Status.OK,
-            statusText: STATUS_TEXT.get(Status.OK),
+            statusText: STATUS_TEXT[Status.OK],
           });
         }
 
@@ -45,16 +46,15 @@ export default function start(port: number) {
         /** Everything worked! We're good to return the keys and OK. */
         return new Response(responseData, {
           status: Status.OK,
-          statusText: STATUS_TEXT.get(Status.OK),
+          statusText: STATUS_TEXT[Status.OK],
         });
       } catch (err) {
         console.error(err);
         return new Response(undefined, {
           status: Status.InternalServerError,
-          statusText: STATUS_TEXT.get(Status.InternalServerError),
+          statusText: STATUS_TEXT[Status.InternalServerError],
         });
       }
     },
-    { addr: `:${port}` },
-  );
+  });
 }


### PR DESCRIPTION
- Upgrade to latest nix unstable version of deno (`v1.37.1`)
- Upgrade to latest deno std library (`0.204.0`)
  - Migrate to new standard `Deno.serve` for main server ([serve](https://deno.land/std@0.204.0/http/server.ts?s=serve) now deprecated)
  - Fix `StatusText` [breaking changes](https://github.com/denoland/deno_std/pull/2297) (changed from a `Map` to a `Record`)