### PR TITLE
Allow application port to be overridden

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM denoland/deno:1.37.1
 
-# The port that your application listens to.
-EXPOSE 8000
-
 WORKDIR /app
 
 # Prefer not to run as root.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM denoland/deno:1.37.1
 
+# Application listens on port 80.
+ENV PORT=80
+EXPOSE $PORT
+
 WORKDIR /app
 
 # Prefer not to run as root.

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ ADD . .
 # Compile the main app so that it doesn't need to be compiled each startup/entry.
 RUN deno cache main.ts
 
-CMD ["run", "--allow-net", "main.ts"]
+CMD ["run", "--allow-net", "--allow-env", "main.ts"]

--- a/README.md
+++ b/README.md
@@ -44,5 +44,7 @@ deno test
 
 ```sh
 docker build -t keys:latest .
-docker run -p 8000:8000 keys:latest
+
+# Run, exposing port 8000 (inner port is always 80)
+docker run -p 8000:80 keys:latest
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ curl "https://keys.demery.net/api?allOf=demery&allOf=thunderbird&noneOf=disabled
 ### Running locally
 
 ```sh
-deno run --allow-net main.ts
+deno run --allow-net --allow-env main.ts
 ```
 
 ### Run tests

--- a/deps.ts
+++ b/deps.ts
@@ -2,3 +2,4 @@ export {
   Status,
   STATUS_TEXT,
 } from "https://deno.land/std@0.204.0/http/http_status.ts";
+export { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -3,3 +3,4 @@ export {
   STATUS_TEXT,
 } from "https://deno.land/std@0.204.0/http/http_status.ts";
 export { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
+export { ZodError } from "https://deno.land/x/zod@v3.22.4/ZodError.ts";

--- a/main.ts
+++ b/main.ts
@@ -1,8 +1,11 @@
 import start from "./src/server.ts";
 import keys from "./src/public_keys.ts";
 import { filterIncludesKey, parseParameters } from "./src/filter.ts";
+import { parseEnvironmentVariables } from "./src/environment.ts";
 
-start(8000, {
+const environment = parseEnvironmentVariables(Deno.env.toObject());
+
+start(environment.PORT, {
   filterIncludesKey,
   parseParameters,
   keys,

--- a/src/environment.test.ts
+++ b/src/environment.test.ts
@@ -1,0 +1,32 @@
+import {
+  assertEquals,
+  assertThrows,
+} from "https://deno.land/std@0.117.0/testing/asserts.ts";
+import { parseEnvironmentVariables } from "./environment.ts";
+import { ZodError } from "../deps.ts";
+
+Deno.test(
+  "parseEnvironmentVariables: must convert string variables to correct types",
+  () => {
+    const variables = {
+      PORT: "1234",
+    };
+
+    assertEquals(parseEnvironmentVariables(variables), { PORT: 1234 });
+  }
+);
+Deno.test(
+  "parseEnvironmentVariables: must use defaults if variables are not supplied",
+  () => {
+    const variables = {};
+
+    assertEquals(parseEnvironmentVariables(variables), { PORT: 8000 });
+  }
+);
+Deno.test("parseEnvironmentVariables: must throw ZodError if input is invalid", () => {
+  const variables = {
+    PORT: "not-a-number",
+  };
+
+  assertThrows(() => parseEnvironmentVariables(variables), ZodError);
+});

--- a/src/environment.test.ts
+++ b/src/environment.test.ts
@@ -13,7 +13,7 @@ Deno.test(
     };
 
     assertEquals(parseEnvironmentVariables(variables), { PORT: 1234 });
-  }
+  },
 );
 Deno.test(
   "parseEnvironmentVariables: must use defaults if variables are not supplied",
@@ -21,12 +21,15 @@ Deno.test(
     const variables = {};
 
     assertEquals(parseEnvironmentVariables(variables), { PORT: 8000 });
-  }
+  },
 );
-Deno.test("parseEnvironmentVariables: must throw ZodError if input is invalid", () => {
-  const variables = {
-    PORT: "not-a-number",
-  };
+Deno.test(
+  "parseEnvironmentVariables: must throw ZodError if input is invalid",
+  () => {
+    const variables = {
+      PORT: "not-a-number",
+    };
 
-  assertThrows(() => parseEnvironmentVariables(variables), ZodError);
-});
+    assertThrows(() => parseEnvironmentVariables(variables), ZodError);
+  },
+);

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,0 +1,9 @@
+import { z } from "../deps.ts";
+
+const environmentSchema = z.object({
+  PORT: z.string().regex(/^\d+$/).transform(Number).default("8000"),
+});
+
+export function parseEnvironmentVariables(variableObject: unknown) {
+  return environmentSchema.parse(variableObject);
+}


### PR DESCRIPTION
- Allows the application port to listen on a custom port
- Defaults to `8000` if not specified
- `Dockerfile` always listens internally on `80`
- Adds validation to environment variables (application doesn't start if invalid)