### PR TITLE
Refactor routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Simple repository to manage and distribute ssh keys.
 
 To see a production implementation of this app feel free to visit
-https://keys.demery.net/api
+https://keys.demery.net/keys
 
 Public keys are provided in a configuration file at application start. The
 application has no persistence layer and is stateless.
@@ -24,7 +24,7 @@ place to prevent loss of access.
 ### Get all listed keys
 
 ```sh
-curl "https://keys.demery.net/api"
+curl "https://keys.demery.net/keys"
 ```
 
 ### Update authorized keys file
@@ -36,7 +36,7 @@ tag and override the `authorized_keys` file with them_
 # Consider backup first
 cp ~/.ssh/authorized_keys ~/.ssh/authorized_keys.`date '+%Y-%m-%d__%H_%M_%S'`.backup
 # Override file with the matching keys
-curl "https://keys.demery.net/api?user=demery&allOf=oak&noneOf=disabled" > ~/.ssh/authorized_keys
+curl "https://keys.demery.net/keys?user=demery&allOf=oak&noneOf=disabled" > ~/.ssh/authorized_keys
 # Check that they keys were updated with what you expected
 cat ~/.ssh/authorized_keys
 ```

--- a/src/filter.test.ts
+++ b/src/filter.test.ts
@@ -6,7 +6,9 @@ Deno.test("parseParameters: must parse oneOf url param", () => {
   const expected: Filter = {
     oneOf: ["simple"],
   };
-  const actual = parseParameters(new URL("http://domain.com/api?oneOf=simple"));
+  const actual = parseParameters(
+    new URL("http://domain.com/keys?oneOf=simple"),
+  );
   assertEquals(actual, expected);
 });
 
@@ -14,7 +16,7 @@ Deno.test("parseParameters: must parse user url param", () => {
   const expected: Filter = {
     user: "sample",
   };
-  const actual = parseParameters(new URL("http://domain.com/api?user=sample"));
+  const actual = parseParameters(new URL("http://domain.com/keys?user=sample"));
   assertEquals(actual, expected);
 });
 
@@ -26,7 +28,7 @@ Deno.test("parseParameters: must parse complex filter params", () => {
   };
   const actual = parseParameters(
     new URL(
-      "http://domain.com/api?noneOf=not-me&noneOf=or-me&allOf=definitely-me&allOf=and-me&user=user-one",
+      "http://domain.com/keys?noneOf=not-me&noneOf=or-me&allOf=definitely-me&allOf=and-me&user=user-one",
     ),
   );
   assertEquals(actual, expected);

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -91,7 +91,7 @@ Deno.test(
     const parseParametersSpy = spy(parseParameters);
     const filterIncludesKeySpy = spy(filterIncludesKey);
 
-    const url = `${TEST_URL}/api?oneOf=private&noneOf=public&noneOf=github`;
+    const url = `${TEST_URL}/keys?oneOf=private&noneOf=public&noneOf=github`;
 
     const response = await handleRequest(new Request(url), {
       parseParameters: parseParametersSpy,
@@ -124,7 +124,7 @@ Deno.test(
     const parseParametersStub = spy(throwingParseParameters);
     const filterIncludesKeyStub = spy(filterIncludesKey);
 
-    const url = `${TEST_URL}/api?oneOf=private&noneOf=public&noneOf=github`;
+    const url = `${TEST_URL}/keys?oneOf=private&noneOf=public&noneOf=github`;
 
     const response = await handleRequest(new Request(url), {
       parseParameters: parseParametersStub,


### PR DESCRIPTION
- The `/api` route has now been moved to `/keys` and `/authorized_keys`.
- Trailing slashes will now also yield a result.
