### PR TITLE
Add a home page

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -30,6 +30,8 @@ spec:
           env:
             - name: KEYS_VERSION
               value: {{ .Values.version | quote }}
+            - name: INSTANCE_NAME
+              value: {{ .Values.name | quote }}
           envFrom:
             - secretRef:
                 name: {{ .Values.secretName }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -9,3 +9,5 @@ configFile:
   name: config.yaml
   # path to mount the config file to
   mountPath: /config.yaml
+# Name for the instance
+name: Unnamed

--- a/main.ts
+++ b/main.ts
@@ -32,6 +32,7 @@ start(
     servePGPKeyList,
     sshKeys,
     pgpKeys,
+    instanceName: environment.INSTANCE_NAME,
   },
   environment.KEYS_VERSION,
 );

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -1,0 +1,23 @@
+import { filterIncludesKey, parseParameters } from "./filter.ts";
+import { PublicSSHKey } from "./load_config.ts";
+import { PGPKey } from "./load_config.ts";
+import { getPGPTarget, servePGPKey, servePGPKeyList } from "./serve_pgp.ts";
+import { serveKeys } from "./serve-keys.ts";
+import { serveHome } from "./serve-home.ts";
+
+/**
+ * The dependencies required by the server.
+ * We use this to make it easier to mock the dependencies in tests.
+ */
+export interface ServerDependencies {
+  instanceName: string;
+  filterIncludesKey: typeof filterIncludesKey;
+  parseParameters: typeof parseParameters;
+  serveHome: typeof serveHome;
+  serveKeys: typeof serveKeys;
+  getPGPTarget: typeof getPGPTarget;
+  servePGPKey: typeof servePGPKey;
+  servePGPKeyList: typeof servePGPKeyList;
+  sshKeys: PublicSSHKey[];
+  pgpKeys: PGPKey[];
+}

--- a/src/environment.test.ts
+++ b/src/environment.test.ts
@@ -9,6 +9,7 @@ const baseVariables = {
   DOPPLER_ENVIRONMENT: "unit_tests",
   KEYS_VERSION: "unit_tests",
   CONFIG_PATH: "/test.yaml",
+  INSTANCE_NAME: "Test",
 };
 
 Deno.test(
@@ -26,14 +27,18 @@ Deno.test(
   },
 );
 Deno.test(
-  "parseEnvironmentVariables: must use defaults if variables are not supplied",
+  "parseEnvironmentVariables: must use defaults if optional variables are not supplied",
   () => {
     const variables = {
-      ...baseVariables,
+      DOPPLER_ENVIRONMENT: "unit_tests",
+      KEYS_VERSION: "unit_tests",
     };
 
     assertEquals(parseEnvironmentVariables(variables), {
-      ...baseVariables,
+      CONFIG_PATH: "/config.yaml",
+      DOPPLER_ENVIRONMENT: "unit_tests",
+      INSTANCE_NAME: "Unnamed",
+      KEYS_VERSION: "unit_tests",
       PORT: 8000,
     });
   },

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -6,6 +6,7 @@ const environmentSchema = z.object({
   SENTRY_DSN: z.string().optional(),
   KEYS_VERSION: z.string(),
   CONFIG_PATH: z.string().optional().default("/config.yaml"),
+  INSTANCE_NAME: z.string().optional().default("Unnamed"),
 });
 
 export function parseEnvironmentVariables(variableObject: unknown) {

--- a/src/serve-home.test.ts
+++ b/src/serve-home.test.ts
@@ -1,0 +1,52 @@
+import { assertEquals } from "https://deno.land/std@0.204.0/assert/mod.ts";
+import { serveHome } from "./serve-home.ts";
+import { ServerDependencies } from "./server.ts";
+
+const emptyDependencies: ServerDependencies = {
+  filterIncludesKey: () => false,
+  parseParameters: () => ({}),
+  serveHome: () => new Response(""),
+  serveKeys: () => new Response(""),
+  getPGPTarget: () => undefined,
+  servePGPKey: () => new Response(""),
+  servePGPKeyList: () => new Response(""),
+  sshKeys: [],
+  pgpKeys: [],
+  instanceName: "unit-tests",
+};
+
+Deno.test("serveKeys: must return 200 for valid requests", async () => {
+  const response = await serveHome(
+    "unit-tests",
+    {
+      ...emptyDependencies,
+      sshKeys: [{
+        key: "ssh-rsa fake1",
+        name: "key-1",
+        tags: ["private"],
+        user: "demery",
+      }],
+    },
+    "text/plain",
+  );
+  assertEquals(response.status, 200);
+  assertEquals(response.statusText, "OK");
+  const responseText = await response.text();
+  assertEquals(
+    responseText,
+    `Welcome to the "unit-tests" keys instance.
+There are 1 SSH keys available at /keys.
+There are 0 PGP keys available at /pgp.
+This server is running version unit-tests.`,
+  );
+});
+
+Deno.test("serveKeys: must return NotAcceptable for unsupported content type", async () => {
+  const response = await serveHome(
+    "unit-tests",
+    emptyDependencies,
+    "text/html",
+  );
+  assertEquals(response.status, 406);
+  assertEquals(response.statusText, "Not Acceptable");
+});

--- a/src/serve-home.test.ts
+++ b/src/serve-home.test.ts
@@ -1,19 +1,6 @@
 import { assertEquals } from "https://deno.land/std@0.204.0/assert/mod.ts";
 import { serveHome } from "./serve-home.ts";
-import { ServerDependencies } from "./server.ts";
-
-const emptyDependencies: ServerDependencies = {
-  filterIncludesKey: () => false,
-  parseParameters: () => ({}),
-  serveHome: () => new Response(""),
-  serveKeys: () => new Response(""),
-  getPGPTarget: () => undefined,
-  servePGPKey: () => new Response(""),
-  servePGPKeyList: () => new Response(""),
-  sshKeys: [],
-  pgpKeys: [],
-  instanceName: "unit-tests",
-};
+import { emptyDependencies } from "./test_helpers.ts";
 
 Deno.test("serveKeys: must return 200 for valid requests", async () => {
   const response = await serveHome(

--- a/src/serve-home.ts
+++ b/src/serve-home.ts
@@ -1,6 +1,6 @@
 import { STATUS_CODE, STATUS_TEXT } from "@std/http";
 import { ContentType } from "./content-types.ts";
-import { ServerDependencies } from "./server.ts";
+import { ServerDependencies } from "./dependencies.ts";
 
 export function serveHome(
   version: string,

--- a/src/serve-home.ts
+++ b/src/serve-home.ts
@@ -1,0 +1,38 @@
+import { STATUS_CODE, STATUS_TEXT } from "@std/http";
+import { ContentType } from "./content-types.ts";
+import { ServerDependencies } from "./server.ts";
+
+export function serveHome(
+  version: string,
+  dependencies: ServerDependencies,
+  contentType: ContentType,
+) {
+  switch (contentType) {
+    case "text/plain":
+      return new Response(
+        generateTextBody(version, dependencies),
+        {
+          status: 200,
+          statusText: "OK",
+          headers: {
+            "X-Keys-Version": version,
+          },
+        },
+      );
+    default:
+      return new Response(undefined, {
+        status: STATUS_CODE.NotAcceptable,
+        statusText: STATUS_TEXT[STATUS_CODE.NotAcceptable],
+      });
+  }
+}
+
+function generateTextBody(
+  version: string,
+  serverDependencies: ServerDependencies,
+) {
+  return `Welcome to the "${serverDependencies.instanceName}" keys instance.
+There are ${serverDependencies.sshKeys.length} SSH keys available at /keys.
+There are ${serverDependencies.pgpKeys.length} PGP keys available at /pgp.
+This server is running version ${version}.`;
+}

--- a/src/serve-keys.test.ts
+++ b/src/serve-keys.test.ts
@@ -19,6 +19,7 @@ const emptyDependencies: ServerDependencies = {
   servePGPKeyList: () => new Response(""),
   sshKeys: [],
   pgpKeys: [],
+  instanceName: "unit-tests",
 };
 
 const fakeKeys: PublicSSHKey[] = [

--- a/src/serve-keys.test.ts
+++ b/src/serve-keys.test.ts
@@ -13,6 +13,7 @@ const TEST_URL = "http://localhost";
 const emptyDependencies: ServerDependencies = {
   filterIncludesKey: () => false,
   parseParameters: () => ({}),
+  serveHome: () => new Response(""),
   serveKeys: () => new Response(""),
   getPGPTarget: () => undefined,
   servePGPKey: () => new Response(""),

--- a/src/serve-keys.test.ts
+++ b/src/serve-keys.test.ts
@@ -4,24 +4,11 @@ import {
   assertSpyCalls,
   spy,
 } from "https://deno.land/std@0.204.0/testing/mock.ts";
-import { ServerDependencies } from "./server.ts";
 import { serveKeys } from "./serve-keys.ts";
 import { PublicSSHKey } from "./load_config.ts";
+import { emptyDependencies } from "./test_helpers.ts";
 
 const TEST_URL = "http://localhost";
-
-const emptyDependencies: ServerDependencies = {
-  filterIncludesKey: () => false,
-  parseParameters: () => ({}),
-  serveHome: () => new Response(""),
-  serveKeys: () => new Response(""),
-  getPGPTarget: () => undefined,
-  servePGPKey: () => new Response(""),
-  servePGPKeyList: () => new Response(""),
-  sshKeys: [],
-  pgpKeys: [],
-  instanceName: "unit-tests",
-};
 
 const fakeKeys: PublicSSHKey[] = [
   {

--- a/src/serve-keys.ts
+++ b/src/serve-keys.ts
@@ -1,5 +1,5 @@
 import { STATUS_CODE, STATUS_TEXT } from "@std/http";
-import { ServerDependencies } from "./server.ts";
+import { ServerDependencies } from "./dependencies.ts";
 import { ContentType } from "./content-types.ts";
 
 export function serveKeys(

--- a/src/serve_pgp.test.ts
+++ b/src/serve_pgp.test.ts
@@ -11,6 +11,7 @@ import { ServerDependencies } from "./server.ts";
 const emptyDependencies: ServerDependencies = {
   filterIncludesKey: () => false,
   parseParameters: () => ({}),
+  serveHome: () => new Response(""),
   serveKeys: () => new Response(""),
   getPGPTarget: () => undefined,
   servePGPKey: () => new Response(""),

--- a/src/serve_pgp.test.ts
+++ b/src/serve_pgp.test.ts
@@ -17,6 +17,7 @@ const emptyDependencies: ServerDependencies = {
   servePGPKeyList: () => new Response(""),
   sshKeys: [],
   pgpKeys: [],
+  instanceName: "unit-tests",
 };
 
 Deno.test("servePGPKeyList (plain): must return the list of key names", async () => {

--- a/src/serve_pgp.test.ts
+++ b/src/serve_pgp.test.ts
@@ -1,3 +1,4 @@
+import { emptyDependencies } from "./test_helpers.ts";
 import {
   getPGPTarget,
   isValidPGPExtension,
@@ -6,20 +7,6 @@ import {
 } from "./serve_pgp.ts";
 
 import { assertEquals } from "https://deno.land/std@0.204.0/assert/mod.ts";
-import { ServerDependencies } from "./server.ts";
-
-const emptyDependencies: ServerDependencies = {
-  filterIncludesKey: () => false,
-  parseParameters: () => ({}),
-  serveHome: () => new Response(""),
-  serveKeys: () => new Response(""),
-  getPGPTarget: () => undefined,
-  servePGPKey: () => new Response(""),
-  servePGPKeyList: () => new Response(""),
-  sshKeys: [],
-  pgpKeys: [],
-  instanceName: "unit-tests",
-};
 
 Deno.test("servePGPKeyList (plain): must return the list of key names", async () => {
   const pgpKeys = [

--- a/src/serve_pgp.ts
+++ b/src/serve_pgp.ts
@@ -1,6 +1,6 @@
 import { STATUS_CODE, STATUS_TEXT } from "@std/http";
-import { ServerDependencies } from "./server.ts";
 import { ContentType } from "./content-types.ts";
+import { ServerDependencies } from "./dependencies.ts";
 
 export const validPGPExtensions = ["asc", "pub", "pgp"] as const;
 export type ValidPGPExtension = typeof validPGPExtensions[number];

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,6 +1,8 @@
-import { handleRequest, ServerDependencies } from "./server.ts";
+import { handleRequest } from "./server.ts";
 import { servePGPKeyList } from "./serve_pgp.ts";
 import { serveKeys } from "./serve-keys.ts";
+import { ServerDependencies } from "./dependencies.ts";
+import { emptyDependencies } from "./test_helpers.ts";
 
 import { assertEquals } from "https://deno.land/std@0.204.0/assert/mod.ts";
 import {
@@ -29,19 +31,6 @@ const fakeKeys = [
 const acceptPlainHeaders = new Headers({
   "Accept": "text/plain",
 });
-
-const emptyDependencies: ServerDependencies = {
-  filterIncludesKey: () => false,
-  parseParameters: () => ({}),
-  serveHome: () => new Response(""),
-  serveKeys: () => new Response(""),
-  getPGPTarget: () => undefined,
-  servePGPKey: () => new Response(""),
-  servePGPKeyList: () => new Response(""),
-  sshKeys: [],
-  pgpKeys: [],
-  instanceName: "unit-tests",
-};
 
 Deno.test(
   "handleRequest: must return 404 for unknown routes requests",

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -39,6 +39,7 @@ const emptyDependencies: ServerDependencies = {
   servePGPKeyList: () => new Response(""),
   sshKeys: [],
   pgpKeys: [],
+  instanceName: "unit-tests",
 };
 
 Deno.test(

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { PGPKey } from "./load_config.ts";
 import { getPGPTarget, servePGPKey, servePGPKeyList } from "./serve_pgp.ts";
 import { getContentType } from "./content-types.ts";
 import { serveKeys } from "./serve-keys.ts";
+import { serveHome } from "./serve-home.ts";
 
 /**
  * The dependencies required by the server.
@@ -14,6 +15,7 @@ export interface ServerDependencies {
   instanceName: string;
   filterIncludesKey: typeof filterIncludesKey;
   parseParameters: typeof parseParameters;
+  serveHome: typeof serveHome;
   serveKeys: typeof serveKeys;
   getPGPTarget: typeof getPGPTarget;
   servePGPKey: typeof servePGPKey;
@@ -46,6 +48,7 @@ const validSSHKeyRoutes = [
   "/authorized_keys/",
 ];
 const validPGPKeyRoutes = ["/pgp", "/pgp/"];
+const validHomeRoutes = ["/"];
 
 export function handleRequest(
   req: Request,
@@ -55,7 +58,7 @@ export function handleRequest(
   // Extract content type
   const contentType = getContentType(req.headers);
 
-  const { serveKeys, servePGPKeyList, getPGPTarget, servePGPKey } =
+  const { serveHome, serveKeys, servePGPKeyList, getPGPTarget, servePGPKey } =
     dependencies;
   try {
     const url = new URL(req.url);
@@ -77,6 +80,11 @@ export function handleRequest(
     // For each supported keys endpoint serve the keys
     if (validSSHKeyRoutes.includes(url.pathname)) {
       return serveKeys(url, version, dependencies, contentType);
+    }
+
+    // For each supported home endpoint serve the home page
+    if (validHomeRoutes.includes(url.pathname)) {
+      return serveHome(version, dependencies, contentType);
     }
 
     // If the url is not recognized, return a 404.

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,28 +1,6 @@
 import { STATUS_CODE, STATUS_TEXT } from "@std/http";
-import { filterIncludesKey, parseParameters } from "./filter.ts";
-import { PublicSSHKey } from "./load_config.ts";
-import { PGPKey } from "./load_config.ts";
-import { getPGPTarget, servePGPKey, servePGPKeyList } from "./serve_pgp.ts";
 import { getContentType } from "./content-types.ts";
-import { serveKeys } from "./serve-keys.ts";
-import { serveHome } from "./serve-home.ts";
-
-/**
- * The dependencies required by the server.
- * We use this to make it easier to mock the dependencies in tests.
- */
-export interface ServerDependencies {
-  instanceName: string;
-  filterIncludesKey: typeof filterIncludesKey;
-  parseParameters: typeof parseParameters;
-  serveHome: typeof serveHome;
-  serveKeys: typeof serveKeys;
-  getPGPTarget: typeof getPGPTarget;
-  servePGPKey: typeof servePGPKey;
-  servePGPKeyList: typeof servePGPKeyList;
-  sshKeys: PublicSSHKey[];
-  pgpKeys: PGPKey[];
-}
+import { ServerDependencies } from "./dependencies.ts";
 
 /**
  * Start a simple http server that listens on the provided port and provides authorized keys based on query string filter

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import { serveKeys } from "./serve-keys.ts";
  * We use this to make it easier to mock the dependencies in tests.
  */
 export interface ServerDependencies {
+  instanceName: string;
   filterIncludesKey: typeof filterIncludesKey;
   parseParameters: typeof parseParameters;
   serveKeys: typeof serveKeys;

--- a/src/test_helpers.ts
+++ b/src/test_helpers.ts
@@ -1,0 +1,18 @@
+import { ServerDependencies } from "./dependencies.ts";
+
+/**
+ * An empty set of dependencies.
+ * Intended for use as a base in tests.
+ */
+export const emptyDependencies: ServerDependencies = {
+  filterIncludesKey: () => false,
+  parseParameters: () => ({}),
+  serveHome: () => new Response(""),
+  serveKeys: () => new Response(""),
+  getPGPTarget: () => undefined,
+  servePGPKey: () => new Response(""),
+  servePGPKeyList: () => new Response(""),
+  sshKeys: [],
+  pgpKeys: [],
+  instanceName: "unit-tests",
+};


### PR DESCRIPTION
- Gives some basic information about the instance
  - It's name - (a new option)
  - The number of loaded ssh keys
  - The number of loaded PGP keys
  - The version the instance is running
- Plain text only (html and json still reserved to be done in #34 and #33 respectively)