### PR TITLE
Hotfix: Add missing serveHome dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run linter
         run: deno lint
 
+      - name: Check typescript
+        run: deno check main.ts
+
       - name: Run tests
         env:
           DOPPLER_ENVIRONMENT: gitlab_ci

--- a/main.ts
+++ b/main.ts
@@ -5,6 +5,7 @@ import { Sentry } from "./deps.ts";
 import loadConfig from "./src/load_config.ts";
 import { getPGPTarget, servePGPKey, servePGPKeyList } from "./src/serve_pgp.ts";
 import { serveKeys } from "./src/serve-keys.ts";
+import { serveHome } from "./src/serve-home.ts";
 
 const environment = parseEnvironmentVariables(Deno.env.toObject());
 
@@ -26,6 +27,7 @@ start(
   {
     filterIncludesKey,
     parseParameters,
+    serveHome,
     serveKeys,
     getPGPTarget,
     servePGPKey,


### PR DESCRIPTION
- Fix issue of missing dependency introduced in `2.1.0`
- Add `deno check` to the ci job to ensure builds failing deno checks cannot be merged to main in the future