### PR TITLE
Migrated zod from deno.land/x v3 to JSR v4

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,8 @@
     "@std/http": "jsr:@std/http@^1.0.25",
     "@std/testing": "jsr:@std/testing@^1.0.17",
     "@sentry/deno": "npm:@sentry/deno@^10.40.0",
-    "@std/yaml": "jsr:@std/yaml@^1.0.12"
+    "@std/yaml": "jsr:@std/yaml@^1.0.12",
+    "zod": "jsr:@zod/zod@^4"
   },
   "exclude": [
     "examples",

--- a/deno.lock
+++ b/deno.lock
@@ -4,10 +4,8 @@
     "jsr:@std/assert@^1.0.17": "1.0.19",
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/cli@^1.0.28": "1.0.28",
-    "jsr:@std/data-structures@^1.0.10": "1.0.10",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
     "jsr:@std/fmt@^1.0.9": "1.0.9",
-    "jsr:@std/fs@^1.0.22": "1.0.23",
     "jsr:@std/fs@^1.0.23": "1.0.23",
     "jsr:@std/html@^1.0.5": "1.0.5",
     "jsr:@std/http@^1.0.25": "1.0.25",
@@ -18,7 +16,7 @@
     "jsr:@std/streams@^1.0.17": "1.0.17",
     "jsr:@std/testing@^1.0.17": "1.0.17",
     "jsr:@std/yaml@^1.0.12": "1.0.12",
-    "npm:@sentry/deno@*": "10.40.0",
+    "jsr:@zod/zod@4": "4.3.6",
     "npm:@sentry/deno@^10.40.0": "10.40.0"
   },
   "jsr": {
@@ -31,9 +29,6 @@
     "@std/cli@1.0.28": {
       "integrity": "74ef9b976db59ca6b23a5283469c9072be6276853807a83ec6c7ce412135c70a"
     },
-    "@std/data-structures@1.0.10": {
-      "integrity": "f574f86b0e07c69b9edc555fcc814b57d29258bad39fd5a34ba8a80ecf033cfe"
-    },
     "@std/encoding@1.0.10": {
       "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
@@ -41,10 +36,7 @@
       "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
     },
     "@std/fs@1.0.23": {
-      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
-      "dependencies": [
-        "jsr:@std/path"
-      ]
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37"
     },
     "@std/html@1.0.5": {
       "integrity": "4e2d693f474cae8c16a920fa5e15a3b72267b94b84667f11a50c6dd1cb18d35e"
@@ -55,7 +47,7 @@
         "jsr:@std/cli",
         "jsr:@std/encoding",
         "jsr:@std/fmt",
-        "jsr:@std/fs@^1.0.23",
+        "jsr:@std/fs",
         "jsr:@std/html",
         "jsr:@std/media-types",
         "jsr:@std/net",
@@ -84,15 +76,14 @@
     "@std/testing@1.0.17": {
       "integrity": "87bdc2700fa98249d48a17cd72413352d3d3680dcfbdb64947fd0982d6bbf681",
       "dependencies": [
-        "jsr:@std/assert@^1.0.17",
-        "jsr:@std/data-structures",
-        "jsr:@std/fs@^1.0.22",
-        "jsr:@std/internal",
-        "jsr:@std/path"
+        "jsr:@std/assert@^1.0.17"
       ]
     },
     "@std/yaml@1.0.12": {
       "integrity": "7deabca4545bcedd07c5f69ea53acea71b8b4c67562f224e17b90d75944cb20c"
+    },
+    "@zod/zod@4.3.6": {
+      "integrity": "7144e5e11f8ffc3cf6e2fca624f6597a8762898aac9868cc8938e9398b96ffe4"
     }
   },
   "npm": {
@@ -110,86 +101,14 @@
       ]
     }
   },
-  "remote": {
-    "https://deno.land/std@0.117.0/fmt/colors.ts": "8368ddf2d48dfe413ffd04cdbb7ae6a1009cf0dccc9c7ff1d76259d9c61a0621",
-    "https://deno.land/std@0.117.0/testing/_diff.ts": "e6a10d2aca8d6c27a9c5b8a2dbbf64353874730af539707b5b39d4128140642d",
-    "https://deno.land/std@0.117.0/testing/asserts.ts": "a1fef0239a2c343b0baa49c77dcdd7412613c46f3aba2887c331a2d7ed1f645e",
-    "https://deno.land/std@0.204.0/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
-    "https://deno.land/std@0.204.0/assert/_diff.ts": "58e1461cc61d8eb1eacbf2a010932bf6a05b79344b02ca38095f9b805795dc48",
-    "https://deno.land/std@0.204.0/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
-    "https://deno.land/std@0.204.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
-    "https://deno.land/std@0.204.0/assert/assert_almost_equals.ts": "e15ca1f34d0d5e0afae63b3f5d975cbd18335a132e42b0c747d282f62ad2cd6c",
-    "https://deno.land/std@0.204.0/assert/assert_array_includes.ts": "6856d7f2c3544bc6e62fb4646dfefa3d1df5ff14744d1bca19f0cbaf3b0d66c9",
-    "https://deno.land/std@0.204.0/assert/assert_equals.ts": "d8ec8a22447fbaf2fc9d7c3ed2e66790fdb74beae3e482855d75782218d68227",
-    "https://deno.land/std@0.204.0/assert/assert_exists.ts": "407cb6b9fb23a835cd8d5ad804e2e2edbbbf3870e322d53f79e1c7a512e2efd7",
-    "https://deno.land/std@0.204.0/assert/assert_false.ts": "0ccbcaae910f52c857192ff16ea08bda40fdc79de80846c206bfc061e8c851c6",
-    "https://deno.land/std@0.204.0/assert/assert_greater.ts": "ae2158a2d19313bf675bf7251d31c6dc52973edb12ac64ac8fc7064152af3e63",
-    "https://deno.land/std@0.204.0/assert/assert_greater_or_equal.ts": "1439da5ebbe20855446cac50097ac78b9742abe8e9a43e7de1ce1426d556e89c",
-    "https://deno.land/std@0.204.0/assert/assert_instance_of.ts": "3aedb3d8186e120812d2b3a5dea66a6e42bf8c57a8bd927645770bd21eea554c",
-    "https://deno.land/std@0.204.0/assert/assert_is_error.ts": "c21113094a51a296ffaf036767d616a78a2ae5f9f7bbd464cd0197476498b94b",
-    "https://deno.land/std@0.204.0/assert/assert_less.ts": "aec695db57db42ec3e2b62e97e1e93db0063f5a6ec133326cc290ff4b71b47e4",
-    "https://deno.land/std@0.204.0/assert/assert_less_or_equal.ts": "5fa8b6a3ffa20fd0a05032fe7257bf985d207b85685fdbcd23651b70f928c848",
-    "https://deno.land/std@0.204.0/assert/assert_match.ts": "c4083f80600bc190309903c95e397a7c9257ff8b5ae5c7ef91e834704e672e9b",
-    "https://deno.land/std@0.204.0/assert/assert_not_equals.ts": "9f1acab95bd1f5fc9a1b17b8027d894509a745d91bac1718fdab51dc76831754",
-    "https://deno.land/std@0.204.0/assert/assert_not_instance_of.ts": "0c14d3dfd9ab7a5276ed8ed0b18c703d79a3d106102077ec437bfe7ed912bd22",
-    "https://deno.land/std@0.204.0/assert/assert_not_match.ts": "3796a5b0c57a1ce6c1c57883dd4286be13a26f715ea662318ab43a8491a13ab0",
-    "https://deno.land/std@0.204.0/assert/assert_not_strict_equals.ts": "ca6c6d645e95fbc873d25320efeb8c4c6089a9a5e09f92d7c1c4b6e935c2a6ad",
-    "https://deno.land/std@0.204.0/assert/assert_object_match.ts": "d8fc2867cfd92eeacf9cea621e10336b666de1874a6767b5ec48988838370b54",
-    "https://deno.land/std@0.204.0/assert/assert_rejects.ts": "45c59724de2701e3b1f67c391d6c71c392363635aad3f68a1b3408f9efca0057",
-    "https://deno.land/std@0.204.0/assert/assert_strict_equals.ts": "b1f538a7ea5f8348aeca261d4f9ca603127c665e0f2bbfeb91fa272787c87265",
-    "https://deno.land/std@0.204.0/assert/assert_string_includes.ts": "b821d39ebf5cb0200a348863c86d8c4c4b398e02012ce74ad15666fc4b631b0c",
-    "https://deno.land/std@0.204.0/assert/assert_throws.ts": "63784e951475cb7bdfd59878cd25a0931e18f6dc32a6077c454b2cd94f4f4bcd",
-    "https://deno.land/std@0.204.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
-    "https://deno.land/std@0.204.0/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
-    "https://deno.land/std@0.204.0/assert/fail.ts": "c36353d7ae6e1f7933d45f8ea51e358c8c4b67d7e7502028598fe1fea062e278",
-    "https://deno.land/std@0.204.0/assert/mod.ts": "37c49a26aae2b254bbe25723434dc28cd7532e444cf0b481a97c045d110ec085",
-    "https://deno.land/std@0.204.0/assert/unimplemented.ts": "d56fbeecb1f108331a380f72e3e010a1f161baa6956fd0f7cf3e095ae1a4c75a",
-    "https://deno.land/std@0.204.0/assert/unreachable.ts": "4600dc0baf7d9c15a7f7d234f00c23bca8f3eba8b140286aaca7aa998cf9a536",
-    "https://deno.land/std@0.204.0/fmt/colors.ts": "c51c4642678eb690dcf5ffee5918b675bf01a33fba82acf303701ae1a4f8c8d9",
-    "https://deno.land/std@0.204.0/testing/mock.ts": "6576b4aa55ee20b1990d656a78fff83599e190948c00e9f25a7f3ac5e9d6492d",
-    "https://deno.land/std@0.99.0/_util/assert.ts": "2f868145a042a11d5ad0a3c748dcf580add8a0dbc0e876eaa0026303a5488f58",
-    "https://deno.land/std@0.99.0/_util/os.ts": "e282950a0eaa96760c0cf11e7463e66babd15ec9157d4c9ed49cc0925686f6a7",
-    "https://deno.land/std@0.99.0/path/_constants.ts": "1247fee4a79b70c89f23499691ef169b41b6ccf01887a0abd131009c5581b853",
-    "https://deno.land/std@0.99.0/path/_interface.ts": "1fa73b02aaa24867e481a48492b44f2598cd9dfa513c7b34001437007d3642e4",
-    "https://deno.land/std@0.99.0/path/_util.ts": "2e06a3b9e79beaf62687196bd4b60a4c391d862cfa007a20fc3a39f778ba073b",
-    "https://deno.land/std@0.99.0/path/common.ts": "eaf03d08b569e8a87e674e4e265e099f237472b6fd135b3cbeae5827035ea14a",
-    "https://deno.land/std@0.99.0/path/glob.ts": "314ad9ff263b895795208cdd4d5e35a44618ca3c6dd155e226fb15d065008652",
-    "https://deno.land/std@0.99.0/path/mod.ts": "4465dc494f271b02569edbb4a18d727063b5dbd6ed84283ff906260970a15d12",
-    "https://deno.land/std@0.99.0/path/posix.ts": "f56c3c99feb47f30a40ce9d252ef6f00296fa7c0fcb6dd81211bdb3b8b99ca3b",
-    "https://deno.land/std@0.99.0/path/separator.ts": "8fdcf289b1b76fd726a508f57d3370ca029ae6976fcde5044007f062e643ff1c",
-    "https://deno.land/std@0.99.0/path/win32.ts": "77f7b3604e0de40f3a7c698e8a79e7f601dc187035a1c21cb1e596666ce112f8",
-    "https://deno.land/x/accepts@2.1.1/deps.ts": "ede05e17882d2e064ecfdfc407c95692cee7b49afe59e31d5f385ff74d262756",
-    "https://deno.land/x/accepts@2.1.1/mod.ts": "ae058b80ba4e560ca9bd1eb4a488f5d6aeed9437fa192bc4903764fa653032cf",
-    "https://deno.land/x/media_types@v2.9.1/db.ts": "ba39cddbcefce47d577c0529066787a3a7b39d27750a6d32b5ad53ed487e7b7b",
-    "https://deno.land/x/media_types@v2.9.1/deps.ts": "364b24c35845cfd5c6903ab22b8ba9873bf1022bbbf6bf3d001695332d4bbb4f",
-    "https://deno.land/x/media_types@v2.9.1/mod.ts": "d63583b978d32eff8b76e1ae5d83cba2fb27baa90cc1bcb0ad15a06122ea8c19",
-    "https://deno.land/x/negotiator@1.0.1/mod.ts": "d8b28a0a7b2d75c944cebef8f87a58eeb344974d432fe0dea85e2d98e03daf24",
-    "https://deno.land/x/negotiator@1.0.1/src/charset.ts": "ca9e78c774c59fed90e31eed9901b6ac78348cbba1adbba71364abdf56dce7e0",
-    "https://deno.land/x/negotiator@1.0.1/src/encoding.ts": "bd3e980c10de08798192cd56f1913e0c9f9be2b56391d7b4213f448cc94a0140",
-    "https://deno.land/x/negotiator@1.0.1/src/language.ts": "bd822581a7621bbe8c3157d38b4f1ec5a35d75eb58bf6be927d477d929e689a2",
-    "https://deno.land/x/negotiator@1.0.1/src/media_type.ts": "bde7a0f6a276fdb3b72569832ca6050ce5bcacad9d493029239af768bd06149f",
-    "https://deno.land/x/negotiator@1.0.1/src/types.ts": "3f2a779b3432bd5e2942965f326d82962e7e9b7a72b30fd81aeb0128f898303d",
-    "https://deno.land/x/sentry@8.26.0/index.mjs": "851bfa3bc942334c8a56a668454385ba4dd422b9d6d64453718136ce83b4acb3",
-    "https://deno.land/x/zod@v3.23.8/ZodError.ts": "528da200fbe995157b9ae91498b103c4ef482217a5c086249507ac850bd78f52",
-    "https://deno.land/x/zod@v3.23.8/errors.ts": "5285922d2be9700cc0c70c95e4858952b07ae193aa0224be3cbd5cd5567eabef",
-    "https://deno.land/x/zod@v3.23.8/external.ts": "a6cfbd61e9e097d5f42f8a7ed6f92f93f51ff927d29c9fbaec04f03cbce130fe",
-    "https://deno.land/x/zod@v3.23.8/helpers/enumUtil.ts": "54efc393cc9860e687d8b81ff52e980def00fa67377ad0bf8b3104f8a5bf698c",
-    "https://deno.land/x/zod@v3.23.8/helpers/errorUtil.ts": "7a77328240be7b847af6de9189963bd9f79cab32bbc61502a9db4fe6683e2ea7",
-    "https://deno.land/x/zod@v3.23.8/helpers/parseUtil.ts": "c14814d167cc286972b6e094df88d7d982572a08424b7cd50f862036b6fcaa77",
-    "https://deno.land/x/zod@v3.23.8/helpers/partialUtil.ts": "998c2fe79795257d4d1cf10361e74492f3b7d852f61057c7c08ac0a46488b7e7",
-    "https://deno.land/x/zod@v3.23.8/helpers/typeAliases.ts": "0fda31a063c6736fc3cf9090dd94865c811dfff4f3cb8707b932bf937c6f2c3e",
-    "https://deno.land/x/zod@v3.23.8/helpers/util.ts": "30c273131661ca5dc973f2cfb196fa23caf3a43e224cdde7a683b72e101a31fc",
-    "https://deno.land/x/zod@v3.23.8/index.ts": "d27aabd973613985574bc31f39e45cb5d856aa122ef094a9f38a463b8ef1a268",
-    "https://deno.land/x/zod@v3.23.8/locales/en.ts": "a7a25cd23563ccb5e0eed214d9b31846305ddbcdb9c5c8f508b108943366ab4c",
-    "https://deno.land/x/zod@v3.23.8/mod.ts": "ec6e2b1255c1a350b80188f97bd0a6bac45801bb46fc48f50b9763aa66046039",
-    "https://deno.land/x/zod@v3.23.8/types.ts": "1b172c90782b1eaa837100ebb6abd726d79d6c1ec336350c8e851e0fd706bf5c"
-  },
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@^1.0.19",
       "jsr:@std/http@^1.0.25",
       "jsr:@std/testing@^1.0.17",
-      "jsr:@std/yaml@^1.0.12"
+      "jsr:@std/yaml@^1.0.12",
+      "jsr:@zod/zod@4",
+      "npm:@sentry/deno@^10.40.0"
     ]
   }
 }

--- a/deps.ts
+++ b/deps.ts
@@ -1,2 +1,0 @@
-export { z } from "https://deno.land/x/zod@v3.23.8/mod.ts";
-export { ZodError } from "https://deno.land/x/zod@v3.23.8/ZodError.ts";

--- a/src/config/load_config.test.ts
+++ b/src/config/load_config.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import loadConfig from "./load_config.ts";
 import { ZodError } from "zod";
 
@@ -23,50 +23,48 @@ Deno.test("loadConfig: must throw syntax error if file is not valid yaml", async
 });
 
 Deno.test("loadConfig: must throw zod error if ssh keys are not valid", async () => {
-  await assertRejects(
+  const err1 = await assertRejects(
     async () => {
       await loadConfig("./fixtures/missing-key.yaml");
     },
     ZodError,
-    `"code": "invalid_type"`,
   );
+  assert(err1.issues.some((i) => i.code === "invalid_type"));
 
-  await assertRejects(
+  const err2 = await assertRejects(
     async () => {
       await loadConfig("./fixtures/missing-field.yaml");
     },
     ZodError,
-    `{
-    "code": "invalid_type",
-    "expected": "string",
-    "received": "undefined",
-    "path": [
-      "ssh-keys",
-      0,
-      "key"
-    ],
-    "message": "Required"
-  }`,
+  );
+  const keyIssue = err2.issues.find((i) =>
+    i.path[0] === "ssh-keys" && i.path[1] === 0 && i.path[2] === "key"
+  );
+  assert(keyIssue);
+  assertEquals(keyIssue.code, "invalid_type");
+  assertEquals(keyIssue.path, ["ssh-keys", 0, "key"]);
+  assertEquals(
+    keyIssue.message,
+    "Invalid input: expected string, received undefined",
   );
 });
 
 Deno.test("loadConfig: must throw zod error if pgp keys are not valid", async () => {
-  await assertRejects(
+  const err = await assertRejects(
     async () => {
       await loadConfig("./fixtures/missing-pgp-key.yaml");
     },
     ZodError,
-    `{
-    "code": "invalid_type",
-    "expected": "string",
-    "received": "undefined",
-    "path": [
-      "pgp-keys",
-      1,
-      "key"
-    ],
-    "message": "Required"
-  }`,
+  );
+  const keyIssue = err.issues.find((i) =>
+    i.path[0] === "pgp-keys" && i.path[1] === 1 && i.path[2] === "key"
+  );
+  assert(keyIssue);
+  assertEquals(keyIssue.code, "invalid_type");
+  assertEquals(keyIssue.path, ["pgp-keys", 1, "key"]);
+  assertEquals(
+    keyIssue.message,
+    "Invalid input: expected string, received undefined",
   );
 });
 
@@ -124,39 +122,33 @@ fake2
 });
 
 Deno.test("loadConfig: must throw zod error if known hosts are not valid", async () => {
-  await assertRejects(
+  const err = await assertRejects(
     async () => {
       await loadConfig("./fixtures/invalid-known-hosts.yaml");
     },
     ZodError,
-    `{
-    "code": "invalid_type",
-    "expected": "array",
-    "received": "string",
-    "path": [
-      "known-hosts",
-      0,
-      "hosts"
-    ],
-    "message": "Expected array, received string"
-  }`,
   );
-  await assertRejects(
-    async () => {
-      await loadConfig("./fixtures/invalid-known-hosts.yaml");
-    },
-    ZodError,
-    `{
-    "code": "invalid_type",
-    "expected": "array",
-    "received": "undefined",
-    "path": [
-      "known-hosts",
-      0,
-      "keys"
-    ],
-    "message": "Required"
-  }`,
+
+  const hostsIssue = err.issues.find((i) =>
+    i.path[0] === "known-hosts" && i.path[1] === 0 && i.path[2] === "hosts"
+  );
+  assert(hostsIssue);
+  assertEquals(hostsIssue.code, "invalid_type");
+  assertEquals(hostsIssue.path, ["known-hosts", 0, "hosts"]);
+  assertEquals(
+    hostsIssue.message,
+    "Invalid input: expected array, received string",
+  );
+
+  const keysIssue = err.issues.find((i) =>
+    i.path[0] === "known-hosts" && i.path[1] === 0 && i.path[2] === "keys"
+  );
+  assert(keysIssue);
+  assertEquals(keysIssue.code, "invalid_type");
+  assertEquals(keysIssue.path, ["known-hosts", 0, "keys"]);
+  assertEquals(
+    keysIssue.message,
+    "Invalid input: expected array, received undefined",
   );
 });
 

--- a/src/config/load_config.test.ts
+++ b/src/config/load_config.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import loadConfig from "./load_config.ts";
-import { ZodError } from "../../deps.ts";
+import { ZodError } from "zod";
 
 Deno.test("loadConfig: must throw error if file is not found", async () => {
   await assertRejects(

--- a/src/config/load_config.ts
+++ b/src/config/load_config.ts
@@ -1,5 +1,5 @@
 import { parse } from "@std/yaml";
-import { z } from "../../deps.ts";
+import { z } from "zod";
 import { loadFileContents } from "../common/file.ts";
 
 export default async function loadConfig(path: string) {

--- a/src/environment/environment.test.ts
+++ b/src/environment/environment.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import { parseEnvironmentVariables } from "../environment/environment.ts";
-import { ZodError } from "../../deps.ts";
+import { ZodError } from "zod";
 
 const baseVariables = {
   DOPPLER_ENVIRONMENT: "unit_tests",

--- a/src/environment/environment.ts
+++ b/src/environment/environment.ts
@@ -1,7 +1,7 @@
-import { z } from "../../deps.ts";
+import { z } from "zod";
 
 const environmentSchema = z.object({
-  PORT: z.string().regex(/^\d+$/).transform(Number).default("8000"),
+  PORT: z.string().regex(/^\d+$/).transform(Number).prefault("8000"),
   DOPPLER_ENVIRONMENT: z.string(),
   SENTRY_DSN: z.string().optional(),
   KEYS_VERSION: z.string(),


### PR DESCRIPTION
Replaced deno.land/x/zod@v3.23.8 with jsr:@zod/zod@^4 in
deno.json imports. Updated all zod consumers to import directly
from the bare specifier instead of deps.ts. Changed .default()
to .prefault() on the PORT transform chain to preserve v3
behavior under v4's new default semantics.

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment now supports two optional variables: CONFIG_PATH (defaults to "/config.yaml") and INSTANCE_NAME (defaults to "Unnamed").

* **Chores**
  * Updated dependency mapping to include a Zod package and adjusted internal dependency exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->