### PR TITLE
Bump deno version (2.7.14 → 2.8.3)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Deno image as the source to copy the Deno executable from.
-FROM denoland/deno:bin-2.7.14 AS deno
+FROM denoland/deno:bin-2.8.3 AS deno
 
 # Use the official TypeScript Node image as a base image.
 # We don't actually use it for much since deno takes care of things, but

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2.0.4
         with:
-          deno-version: v2.7.14
+          deno-version: v2.8.3
 
       - name: Verify formatting
         run: deno fmt --check

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage
 coverage.lcov
 .env
 .claude
+.tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:2.7.14
+FROM denoland/deno:2.8.3
 
 WORKDIR /app
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,27 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/[^/]+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "deno-version:\\s*\"?v?(?<currentValue>\\d+\\.\\d+\\.\\d+)\"?"
+      ],
+      "depNameTemplate": "denoland/deno",
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "denoland/deno"
+      ],
+      "groupName": "deno",
+      "extractVersion": "^(?:bin-)?(?<version>.+)$"
+    }
   ]
 }


### PR DESCRIPTION
- **Bumped Deno version to 2.8.3**
- **Grouped Deno Renovate updates into one PR**
- **Ignored .tmp directory**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime environment from v2.7.14 to v2.8.3 for improved performance and stability.
  * Refined build and deployment configurations for better development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->